### PR TITLE
Too many 's's break a link

### DIFF
--- a/src/main/plugin/iso19139.gemini23/loc/eng/strings.xml
+++ b/src/main/plugin/iso19139.gemini23/loc/eng/strings.xml
@@ -392,7 +392,7 @@
       <p class="help-block">The purpose of this element is to describe any restrictions on usage of the data (as opposed to access).</p>
       <ol class="help-block">
         <li>Any known constraints should be identified. If no conditions apply, then 'no conditions apply' should be recorded.</li>
-        <li>For more guidelines see <a target="_blank" href="https://www.agi.org.uk/40-gemini/1063-gemini-servicess#26">Gemini Guidance</a></li>
+        <li>For more guidelines see <a target="_blank" href="https://www.agi.org.uk/40-gemini/1063-gemini-services#26">Gemini Guidance</a></li>
       </ol>
       </div>
   </div>
@@ -507,7 +507,7 @@
       <p class="help-block">Rectangle enclosing the extent of the data resource described in latitude and longitude.</p>
       <ol class="help-block">
         <li>Draw a rectangle on the map or choose a region using the region picker</li>
-        <li>For more guidelines see <a target="_blank" href="https://www.agi.org.uk/40-gemini/1063-gemini-services#37">Gemini Guidance</a></li>
+        <li>For more guidelines see <a target="_blank" href="https://www.agi.org.uk/40-gemini/1062-gemini-datasets-and-data-series#37">Gemini Guidance</a></li>
       </ol>
       </div>
   </div>


### PR DESCRIPTION
The "For more guidelines see Gemini Guidance" link for Use constraints didn't work
The bbox help link for datasets actually went to the services help