### PR TITLE
Update temporal extent validation rules to work in the metadata editor

### DIFF
--- a/src/main/plugin/iso19139.gemini23/schematron/schematron-rules-GEMINI_2.3_Schema-v1.0.sch
+++ b/src/main/plugin/iso19139.gemini23/schematron/schematron-rules-GEMINI_2.3_Schema-v1.0.sch
@@ -264,16 +264,16 @@
   <sch:pattern fpi="Gemini2-mi7-endpos">
     <sch:rule
       context="
-        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition |
-        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod/gml:endPosition |
-        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition |
-        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod/gml:endPosition">
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod//gml:endPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod//gml:endPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod//gml:endPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod//gml:endPosition">
       <sch:report
         test="((@indeterminatePosition = 'unknown' or @indeterminatePosition = 'now') and normalize-space(.))"
         > MI-7b (Temporal Extent): When indeterminatePosition='unknown' or indeterminatePosition='now' are specified
         endPosition should be empty </sch:report>
       <sch:assert
-        test="string-length() = 0 or string-length() = 4 or string-length() = 7 or string-length() = 10 or string-length() = 19"
+        test="string-length(normalize-space(.))) = 0 or string-length(normalize-space(.))) = 4 or string-length(normalize-space(.))) = 7 or string-length(normalize-space(.))) = 10 or string-length(normalize-space(.))) = 19"
         > MI-7c (Temporal Extent): Date string doesn't have correct length, check it conforms to Gregorian calendar
         and UTC as per ISO 8601 </sch:assert>
     </sch:rule>
@@ -281,14 +281,14 @@
   <sch:pattern fpi="Gemini2-mi7-begpos">
     <sch:rule
       context="
-        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition |
-        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod/gml:beginPosition |
-        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition |
-        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod/gml:beginPosition">
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod//gml:beginPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/gmd:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod//gml:beginPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod//gml:beginPosition |
+        //gmd:MD_Metadata[1]/gmd:identificationInfo[1]/*[1]/srv:extent/*[1]/gmd:temporalElement/*[@gco:isoType = 'gmd:EX_TemporalExtent'][1]/gmd:extent/gml:TimePeriod//gml:beginPosition">
       <sch:report test="(@indeterminatePosition = 'unknown' and normalize-space(.))"> MI-7d (Temporal Extent): When
         indeterminatePosition='unknown' is specified beginPosition should be empty </sch:report>
       <sch:assert
-        test="string-length() = 0 or string-length() = 4 or string-length() = 7 or string-length() = 10 or string-length() = 19"
+        test="string-length(normalize-space(.))) = 0 or string-length(normalize-space(.))) = 4 or string-length(normalize-space(.))) = 7 or string-length(normalize-space(.))) = 10 or string-length(normalize-space(.))) = 19"
         > MI-7e (Temporal Extent): Date string doesn't have correct length, check it conforms to Gregorian calendar
         and UTC as per ISO 8601 </sch:assert>
     </sch:rule>


### PR DESCRIPTION
The metadata editor add some additional elements to the xml, usually in the `geonet` namespace, usually as sibling of the iso19139 elements. But for temporal extent, it adds an extra nested element that causes trouble with the validation rule, see `<gml:TimePeriodTypeCHOICE_ELEMENT2>` below:

```
<gml:TimePeriod gml:id="_d210e84">
  <gml:TimePeriodTypeCHOICE_ELEMENT2>
    <gml:beginPosition indeterminatePosition="before">
```

This pull request updates the related validation rules to work in the metadata editor with the "enhanced" xml and also with the normal xml.